### PR TITLE
Checking socket functionality - compatibility with webpack/browserify

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -161,7 +161,7 @@ function EventSource(url, eventSourceInitDict) {
     });
 
     req.on('error', onConnectionClosed);
-    req.setNoDelay(true);
+    if (req.setNoDelay) req.setNoDelay(true);
     req.end();
   }
 
@@ -176,7 +176,7 @@ function EventSource(url, eventSourceInitDict) {
   this.close = function () {
     if (readyState == EventSource.CLOSED) return;
     readyState = EventSource.CLOSED;
-    req.abort();
+    if (req.abort) req.abort();
   };
 
   function parseEventStreamLine(buf, pos, fieldLength, lineLength) {


### PR DESCRIPTION
~~The code was erroring out for me while on node v4.0  I noticed that at the time of development, it may have attempted to support some [now-deprecated functionality](https://nodejs.org/api/net.html#net_socket_setnodelay_nodelay)~~

Actually I misunderstood the problem - its certainly not deprecated of course :)

The issue was that I was using this library with webpack which doesn't seem to emulate node's `net` module correctly when consumed through commonjs

This PR simply checks for the existence of those methods before calling them