### PR TITLE
emit 'message' event in addition to the specific event

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -182,12 +182,17 @@ function EventSource(url, eventSourceInitDict) {
   function parseEventStreamLine(buf, pos, fieldLength, lineLength) {
     if (lineLength === 0) {
       if (data.length > 0) {
-        var type = eventName || 'message';
-        _emit(type, new MessageEvent(type, {
-          data: data.slice(0, -1), // remove trailing newline
-          lastEventId: lastEventId,
-          origin: original(url)
-        }));
+        function emit(type) {
+          _emit(type, new MessageEvent(type, {
+            data: data.slice(0, -1), // remove trailing newline
+            lastEventId: lastEventId,
+            origin: original(url)
+          }));
+        }
+        if (eventName) {
+          emit(eventName)
+        }
+        emit('message');
         data = '';
       }
       eventName = void 0;

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -1,888 +1,888 @@
 var EventSource = require('../lib/eventsource')
-    , http = require('http')
-    , https = require('https')
-    , fs = require('fs')
-    , assert = require('assert')
-    , u = require('url');
+  , http = require('http')
+  , https = require('https')
+  , fs = require('fs')
+  , assert = require('assert')
+  , u = require('url');
 
 var _port = 20000;
 var servers = 0;
 process.on('exit', function () {
-    if (servers != 0) {
-        console.error("************ Didn't kill all servers - there is still %d running.", servers);
-    }
+  if (servers != 0) {
+    console.error("************ Didn't kill all servers - there is still %d running.", servers);
+  }
 });
 
 function createServer(callback) {
-    var server = http.createServer();
-    configureServer(server, 'http', _port++, callback);
+  var server = http.createServer();
+  configureServer(server, 'http', _port++, callback);
 }
 
 function createHttpsServer(callback) {
-    var options = {
-        key: fs.readFileSync(__dirname + '/key.pem'),
-        cert: fs.readFileSync(__dirname + '/certificate.pem')
-    };
-    var server = https.createServer(options);
-    configureServer(server, 'https', _port++, callback);
+  var options = {
+    key: fs.readFileSync(__dirname + '/key.pem'),
+    cert: fs.readFileSync(__dirname + '/certificate.pem')
+  };
+  var server = https.createServer(options);
+  configureServer(server, 'https', _port++, callback);
 }
 
 function configureServer(server, protocol, port, callback) {
-    var responses = [];
+  var responses = [];
 
-    var oldClose = server.close;
-    server.close = function () {
-        responses.forEach(function (res) {
-            res.end();
-        });
-        servers--;
-        oldClose.apply(this, arguments);
-    };
-
-    server.on('request', function (req, res) {
-        responses.push(res);
+  var oldClose = server.close;
+  server.close = function() {
+    responses.forEach(function (res) {
+      res.end();
     });
+    servers--;
+    oldClose.apply(this, arguments);
+  };
 
-    server.url = protocol + '://localhost:' + port;
+  server.on('request', function (req, res) {
+    responses.push(res);
+  });
 
-    server.listen(port, function onOpen(err) {
-        servers++;
-        callback(err, server);
-    });
+  server.url = protocol + '://localhost:' + port;
+
+  server.listen(port, function onOpen(err) {
+    servers++;
+    callback(err, server);
+  });
 }
 
 function writeEvents(chunks) {
-    return function (req, res) {
-        res.writeHead(200, {'Content-Type': 'text/event-stream'});
-        chunks.forEach(function (chunk) {
-            res.write(chunk);
-        });
-        res.write(':'); // send a dummy comment to ensure that the head is flushed
-    };
+  return function (req, res) {
+    res.writeHead(200, {'Content-Type': 'text/event-stream'});
+    chunks.forEach(function (chunk) {
+      res.write(chunk);
+    });
+    res.write(':'); // send a dummy comment to ensure that the head is flushed
+  };
 }
 
 describe('Parser', function () {
-    it('parses multibyte characters', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('parses multibyte characters', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', writeEvents(["id: 1\ndata: €豆腐\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["id: 1\ndata: €豆腐\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = function (m) {
-                assert.equal("€豆腐", m.data);
-                server.close(done);
-            };
-        });
+      es.onmessage = function (m) {
+        assert.equal("€豆腐", m.data);
+        server.close(done);
+      };
     });
+  });
 
-    it('parses empty lines with multibyte characters', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('parses empty lines with multibyte characters', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', writeEvents(["\n\n\n\nid: 1\ndata: 我現在都看實況不玩遊戲\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["\n\n\n\nid: 1\ndata: 我現在都看實況不玩遊戲\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = function (m) {
-                assert.equal("我現在都看實況不玩遊戲", m.data);
-                server.close(done);
-            };
-        });
+      es.onmessage = function (m) {
+        assert.equal("我現在都看實況不玩遊戲", m.data);
+        server.close(done);
+      };
     });
+  });
 
-    it('parses one one-line message in one chunk', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('parses one one-line message in one chunk', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', writeEvents(["data: Hello\n\n"]));
-            var es = new EventSource(server.url);
-            es.onmessage = function (m) {
-                assert.equal("Hello", m.data);
-                server.close(done);
-            };
-        });
+      server.on('request', writeEvents(["data: Hello\n\n"]));
+      var es = new EventSource(server.url);
+      es.onmessage = function (m) {
+        assert.equal("Hello", m.data);
+        server.close(done);
+      };
     });
+  });
 
-    it('parses one one-line message in two chunks', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('parses one one-line message in two chunks', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', writeEvents(["data: Hel", "lo\n\n"]));
-            var es = new EventSource(server.url);
-            es.onmessage = function (m) {
-                assert.equal("Hello", m.data);
-                server.close(done);
-            };
-        });
+      server.on('request', writeEvents(["data: Hel", "lo\n\n"]));
+      var es = new EventSource(server.url);
+      es.onmessage = function (m) {
+        assert.equal("Hello", m.data);
+        server.close(done);
+      };
     });
+  });
 
-    it('parses two one-line messages in one chunk', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('parses two one-line messages in one chunk', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', writeEvents(["data: Hello\n\n", "data: World\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["data: Hello\n\n", "data: World\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = first;
+      es.onmessage = first;
 
-            function first(m) {
-                assert.equal("Hello", m.data);
-                es.onmessage = second;
-            }
+      function first(m) {
+        assert.equal("Hello", m.data);
+        es.onmessage = second;
+      }
 
-            function second(m) {
-                assert.equal("World", m.data);
-                server.close(done);
-            }
-        });
+      function second(m) {
+        assert.equal("World", m.data);
+        server.close(done);
+      }
     });
+  });
 
-    it('parses one two-line message in one chunk', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('parses one two-line message in one chunk', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', writeEvents(["data: Hello\ndata:World\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["data: Hello\ndata:World\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = function (m) {
-                assert.equal("Hello\nWorld", m.data);
-                server.close(done);
-            };
-        });
+      es.onmessage = function (m) {
+        assert.equal("Hello\nWorld", m.data);
+        server.close(done);
+      };
     });
+  });
 
-    it('parses really chopped up unicode data', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('parses really chopped up unicode data', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            var chopped = "data: Aslak\n\ndata: Hellesøy\n\n".split("");
-            server.on('request', writeEvents(chopped));
-            var es = new EventSource(server.url);
+      var chopped = "data: Aslak\n\ndata: Hellesøy\n\n".split("");
+      server.on('request', writeEvents(chopped));
+      var es = new EventSource(server.url);
 
-            es.onmessage = first;
+      es.onmessage = first;
 
-            function first(m) {
-                assert.equal("Aslak", m.data);
-                es.onmessage = second;
-            }
+      function first(m) {
+        assert.equal("Aslak", m.data);
+        es.onmessage = second;
+      }
 
-            function second(m) {
-                assert.equal("Hellesøy", m.data);
-                server.close(done);
-            }
-        });
+      function second(m) {
+        assert.equal("Hellesøy", m.data);
+        server.close(done);
+      }
     });
+  });
 
-    it('accepts CRLF as separator', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('accepts CRLF as separator', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            var chopped = "data: Aslak\r\n\r\ndata: Hellesøy\r\n\r\n".split("");
-            server.on('request', writeEvents(chopped));
-            var es = new EventSource(server.url);
+      var chopped = "data: Aslak\r\n\r\ndata: Hellesøy\r\n\r\n".split("");
+      server.on('request', writeEvents(chopped));
+      var es = new EventSource(server.url);
 
-            es.onmessage = first;
+      es.onmessage = first;
 
-            function first(m) {
-                assert.equal("Aslak", m.data);
-                es.onmessage = second;
-            }
+      function first(m) {
+        assert.equal("Aslak", m.data);
+        es.onmessage = second;
+      }
 
-            function second(m) {
-                assert.equal("Hellesøy", m.data);
-                server.close(done);
-            }
-        });
+      function second(m) {
+        assert.equal("Hellesøy", m.data);
+        server.close(done);
+      }
     });
+  });
 
-    it('accepts CR as separator', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('accepts CR as separator', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            var chopped = "data: Aslak\r\rdata: Hellesøy\r\r".split("");
-            server.on('request', writeEvents(chopped));
-            var es = new EventSource(server.url);
+      var chopped = "data: Aslak\r\rdata: Hellesøy\r\r".split("");
+      server.on('request', writeEvents(chopped));
+      var es = new EventSource(server.url);
 
-            es.onmessage = first;
+      es.onmessage = first;
 
-            function first(m) {
-                assert.equal("Aslak", m.data);
-                es.onmessage = second;
-            }
+      function first(m) {
+        assert.equal("Aslak", m.data);
+        es.onmessage = second;
+      }
 
-            function second(m) {
-                assert.equal("Hellesøy", m.data);
-                server.close(done);
-            }
-        });
+      function second(m) {
+        assert.equal("Hellesøy", m.data);
+        server.close(done);
+      }
     });
+  });
 
-    it('raises an event with a specific key when a message has the event set', function (done) {
-        raiseEventAndCheck('greeting','greeting', done);
+  it('raises an event with a specific key when a message has the event set', function (done) {
+    raiseEventAndCheck('greeting','greeting', done);
+  });
+
+  it('raises an event with a generic \'message\' key when a message has the event set', function (done) {
+    raiseEventAndCheck('greeting','message', done);
+  });
+
+  it('raises an event with a generic \'message\' key when the event is not set', function (done) {
+    raiseEventAndCheck('','message', done);
+  });
+
+  function raiseEventAndCheck(sseEventKey, eventListenerKey, done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
+
+      var event = (sseEventKey ? "event: " + sseEventKey + "\n" : "") + "data: Hello\n\n";
+      server.on('request', writeEvents([event]));
+      var es = new EventSource(server.url);
+
+      es.addEventListener(eventListenerKey, function (m) {
+        assert.equal("Hello", m.data);
+        server.close(done);
+      });
     });
+  }
 
-    it('raises an event with a generic \'message\' key when a message has the event set', function (done) {
-        raiseEventAndCheck('greeting','message', done);
+  it('ignores comments', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
+
+      server.on('request', writeEvents(["data: Hello\n\n:nothing to see here\n\ndata: World\n\n"]));
+      var es = new EventSource(server.url);
+
+      es.onmessage = first;
+
+      function first(m) {
+        assert.equal("Hello", m.data);
+        es.onmessage = second;
+      }
+
+      function second(m) {
+        assert.equal("World", m.data);
+        server.close(done);
+      }
     });
+  });
 
-    it('raises an event with a generic \'message\' key when the event is not set', function (done) {
-        raiseEventAndCheck('','message', done);
+  it('ignores empty comments', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
+
+      server.on('request', writeEvents(["data: Hello\n\n:\n\ndata: World\n\n"]));
+      var es = new EventSource(server.url);
+
+      es.onmessage = first;
+
+      function first(m) {
+        assert.equal("Hello", m.data);
+        es.onmessage = second;
+      }
+
+      function second(m) {
+        assert.equal("World", m.data);
+        server.close(done);
+      }
     });
+  });
 
-    function raiseEventAndCheck(sseEventKey, eventListenerKey, done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('does not ignore multilines strings', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            var event = (sseEventKey ? "event: " + sseEventKey + "\n" : "") + "data: Hello\n\n";
-            server.on('request', writeEvents([event]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["data: line one\ndata:\ndata: line two\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.addEventListener(eventListenerKey, function (m) {
-                assert.equal("Hello", m.data);
-                server.close(done);
-            });
-        });
-    }
-
-    it('ignores comments', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
-
-            server.on('request', writeEvents(["data: Hello\n\n:nothing to see here\n\ndata: World\n\n"]));
-            var es = new EventSource(server.url);
-
-            es.onmessage = first;
-
-            function first(m) {
-                assert.equal("Hello", m.data);
-                es.onmessage = second;
-            }
-
-            function second(m) {
-                assert.equal("World", m.data);
-                server.close(done);
-            }
-        });
+      es.onmessage = function (m) {
+        assert.equal('line one\n\nline two', m.data);
+        server.close(done);
+      };
     });
+  });
 
-    it('ignores empty comments', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('does not ignore multilines strings even in data beginning', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', writeEvents(["data: Hello\n\n:\n\ndata: World\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["data:\ndata:line one\ndata: line two\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = first;
-
-            function first(m) {
-                assert.equal("Hello", m.data);
-                es.onmessage = second;
-            }
-
-            function second(m) {
-                assert.equal("World", m.data);
-                server.close(done);
-            }
-        });
+      es.onmessage = function (m) {
+        assert.equal('\nline one\nline two', m.data);
+        server.close(done);
+      };
     });
+  });
 
-    it('does not ignore multilines strings', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('causes entire event to be ignored for empty event field', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', writeEvents(["data: line one\ndata:\ndata: line two\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["event:\n\ndata: Hello\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = function (m) {
-                assert.equal('line one\n\nline two', m.data);
-                server.close(done);
-            };
-        });
+      var originalEmit = es.emit;
+      es.emit = function (event) {
+        assert.ok(event === 'message' || event === 'newListener');
+        return originalEmit.apply(this, arguments);
+      };
+      es.onmessage = function (m) {
+        assert.equal('Hello', m.data);
+        server.close(done);
+      };
     });
+  });
 
-    it('does not ignore multilines strings even in data beginning', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('parses relatively huge messages efficiently', function (done) {
+    this.timeout(1000);
 
-            server.on('request', writeEvents(["data:\ndata:line one\ndata: line two\n\n"]));
-            var es = new EventSource(server.url);
+    createServer(function (err, server) {
+      if (err) return done(err);
+      var longMessage = "data: " + new Array(100000).join('a') + "\n\n";
+      server.on('request', writeEvents([longMessage]));
 
-            es.onmessage = function (m) {
-                assert.equal('\nline one\nline two', m.data);
-                server.close(done);
-            };
-        });
+      var es = new EventSource(server.url);
+
+      es.onmessage = function () {
+        server.close(done);
+      };
     });
-
-    it('causes entire event to be ignored for empty event field', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
-
-            server.on('request', writeEvents(["event:\n\ndata: Hello\n\n"]));
-            var es = new EventSource(server.url);
-
-            var originalEmit = es.emit;
-            es.emit = function (event) {
-                assert.ok(event === 'message' || event === 'newListener');
-                return originalEmit.apply(this, arguments);
-            };
-            es.onmessage = function (m) {
-                assert.equal('Hello', m.data);
-                server.close(done);
-            };
-        });
-    });
-
-    it('parses relatively huge messages efficiently', function (done) {
-        this.timeout(1000);
-
-        createServer(function (err, server) {
-            if (err) return done(err);
-            var longMessage = "data: " + new Array(100000).join('a') + "\n\n";
-            server.on('request', writeEvents([longMessage]));
-
-            var es = new EventSource(server.url);
-
-            es.onmessage = function () {
-                server.close(done);
-            };
-        });
-    });
+  });
 });
 
 describe('HTTP Request', function () {
-    it('passes cache-control: no-cache to server', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('passes cache-control: no-cache to server', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err);
 
-            server.on('request', function (req) {
-                assert.equal('no-cache', req.headers['cache-control']);
-                server.close(done);
+      server.on('request', function (req) {
+        assert.equal('no-cache', req.headers['cache-control']);
+        server.close(done);
+      });
+      new EventSource(server.url);
+    });
+  });
+
+  it('sets request headers', function (done) {
+    var server = createServer(function (err, server) {
+      if (err) return done(err);
+
+      server.on('request', function (req) {
+        assert.equal(req.headers['user-agent'], 'test');
+        assert.equal(req.headers['cookie'], 'test=test');
+        assert.equal(req.headers['last-event-id'], '99');
+        server.close(done);
+      });
+
+      var headers = {
+        'User-Agent': 'test',
+        'Cookie': 'test=test',
+        'Last-Event-ID': '99'
+      };
+      new EventSource(server.url, {headers: headers});
+    });
+  });
+
+  it("does not set request headers that don't have a value", function (done) {
+    var server = createServer(function (err, server) {
+      if (err) return done(err);
+
+      server.on('request', function (req) {
+        assert.equal(req.headers['user-agent'], 'test');
+        assert.equal(req.headers['cookie'], 'test=test');
+        assert.equal(req.headers['last-event-id'], '99');
+        assert.equal(req.headers['X-Something'], undefined);
+        server.close(done);
+      });
+
+      var headers = {
+        'User-Agent': 'test',
+        'Cookie': 'test=test',
+        'Last-Event-ID': '99',
+        'X-Something': null
+      };
+
+      assert.doesNotThrow(
+        function() {
+          new EventSource(server.url, {headers: headers});
+        }
+      );
+    });
+  });
+
+  [301, 307].forEach(function (status) {
+    it('follows http ' + status + ' redirect', function (done) {
+      var redirectSuffix = '/foobar';
+      var clientRequestedRedirectUrl = false;
+      createServer(function (err, server) {
+        if(err) return done(err);
+
+        server.on('request', function (req, res) {
+          if (req.url === '/') {
+            res.writeHead(status, {
+              'Connection': 'Close',
+              'Location': server.url + redirectSuffix
             });
-            new EventSource(server.url);
+            res.end();
+          } else if (req.url === redirectSuffix) {
+            clientRequestedRedirectUrl = true;
+            res.writeHead(200, {'Content-Type': 'text/event-stream'});
+            res.end();
+          }
         });
+
+        var es = new EventSource(server.url);
+        es.onopen = function () {
+          assert.ok(clientRequestedRedirectUrl);
+          assert.equal(server.url + redirectSuffix, es.url);
+          server.close(done);
+        };
+      });
     });
 
-    it('sets request headers', function (done) {
-        var server = createServer(function (err, server) {
-            if (err) return done(err);
 
-            server.on('request', function (req) {
-                assert.equal(req.headers['user-agent'], 'test');
-                assert.equal(req.headers['cookie'], 'test=test');
-                assert.equal(req.headers['last-event-id'], '99');
-                server.close(done);
-            });
+    it('causes error event when response is ' + status + ' with missing location', function (done) {
+      var redirectSuffix = '/foobar';
+      var clientRequestedRedirectUrl = false;
+      createServer(function (err, server) {
+        if(err) return done(err);
 
-            var headers = {
-                'User-Agent': 'test',
-                'Cookie': 'test=test',
-                'Last-Event-ID': '99'
-            };
-            new EventSource(server.url, {headers: headers});
+        server.on('request', function (req, res) {
+          res.writeHead(status, {
+            'Connection': 'Close'
+          });
+          res.end();
         });
+
+        var es = new EventSource(server.url);
+        es.onerror = function (err) {
+          assert.equal(err.status, status);
+          server.close(done);
+        };
+      });
     });
+  });
 
-    it("does not set request headers that don't have a value", function (done) {
-        var server = createServer(function (err, server) {
-            if (err) return done(err);
+  [401, 403].forEach(function (status) {
+    it('causes error event when response status is ' + status, function (done) {
+      createServer(function (err, server) {
+        if(err) return done(err);
 
-            server.on('request', function (req) {
-                assert.equal(req.headers['user-agent'], 'test');
-                assert.equal(req.headers['cookie'], 'test=test');
-                assert.equal(req.headers['last-event-id'], '99');
-                assert.equal(req.headers['X-Something'], undefined);
-                server.close(done);
-            });
-
-            var headers = {
-                'User-Agent': 'test',
-                'Cookie': 'test=test',
-                'Last-Event-ID': '99',
-                'X-Something': null
-            };
-
-            assert.doesNotThrow(
-                function () {
-                    new EventSource(server.url, {headers: headers});
-                }
-            );
+        server.on('request', function (req, res) {
+          res.writeHead(status, {'Content-Type': 'text/html'});
+          res.end();
         });
+
+        var es = new EventSource(server.url);
+        es.onerror = function (err) {
+          assert.equal(err.status, status);
+          server.close(done);
+        };
+      });
     });
-
-    [301, 307].forEach(function (status) {
-        it('follows http ' + status + ' redirect', function (done) {
-            var redirectSuffix = '/foobar';
-            var clientRequestedRedirectUrl = false;
-            createServer(function (err, server) {
-                if (err) return done(err);
-
-                server.on('request', function (req, res) {
-                    if (req.url === '/') {
-                        res.writeHead(status, {
-                            'Connection': 'Close',
-                            'Location': server.url + redirectSuffix
-                        });
-                        res.end();
-                    } else if (req.url === redirectSuffix) {
-                        clientRequestedRedirectUrl = true;
-                        res.writeHead(200, {'Content-Type': 'text/event-stream'});
-                        res.end();
-                    }
-                });
-
-                var es = new EventSource(server.url);
-                es.onopen = function () {
-                    assert.ok(clientRequestedRedirectUrl);
-                    assert.equal(server.url + redirectSuffix, es.url);
-                    server.close(done);
-                };
-            });
-        });
-
-
-        it('causes error event when response is ' + status + ' with missing location', function (done) {
-            var redirectSuffix = '/foobar';
-            var clientRequestedRedirectUrl = false;
-            createServer(function (err, server) {
-                if (err) return done(err);
-
-                server.on('request', function (req, res) {
-                    res.writeHead(status, {
-                        'Connection': 'Close'
-                    });
-                    res.end();
-                });
-
-                var es = new EventSource(server.url);
-                es.onerror = function (err) {
-                    assert.equal(err.status, status);
-                    server.close(done);
-                };
-            });
-        });
-    });
-
-    [401, 403].forEach(function (status) {
-        it('causes error event when response status is ' + status, function (done) {
-            createServer(function (err, server) {
-                if (err) return done(err);
-
-                server.on('request', function (req, res) {
-                    res.writeHead(status, {'Content-Type': 'text/html'});
-                    res.end();
-                });
-
-                var es = new EventSource(server.url);
-                es.onerror = function (err) {
-                    assert.equal(err.status, status);
-                    server.close(done);
-                };
-            });
-        });
-    });
+  });
 });
 
 describe('HTTPS Support', function () {
-    it('uses https for https urls', function (done) {
-        createHttpsServer(function (err, server) {
-            if (err) return done(err);
+  it('uses https for https urls', function (done) {
+    createHttpsServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents(["data: hello\n\n"]));
-            var es = new EventSource(server.url, {rejectUnauthorized: false});
+      server.on('request', writeEvents(["data: hello\n\n"]));
+      var es = new EventSource(server.url, {rejectUnauthorized: false});
 
-            es.onmessage = function (m) {
-                assert.equal("hello", m.data);
-                server.close(done);
-            }
-        });
+      es.onmessage = function (m) {
+        assert.equal("hello", m.data);
+        server.close(done);
+      }
     });
+  });
 });
 
 describe('Reconnection', function () {
-    it('is attempted when server is down', function (done) {
-        var es = new EventSource('http://localhost:' + _port);
-        es.reconnectInterval = 0;
+  it('is attempted when server is down', function (done) {
+    var es = new EventSource('http://localhost:' + _port);
+    es.reconnectInterval = 0;
 
-        es.onerror = function () {
-            es.onerror = null;
-            createServer(function (err, server) {
-                if (err) return done(err);
+    es.onerror = function () {
+      es.onerror = null;
+      createServer(function (err, server) {
+        if(err) return done(err);
 
-                server.on('request', writeEvents(["data: hello\n\n"]));
+        server.on('request', writeEvents(["data: hello\n\n"]));
 
-                es.onmessage = function (m) {
-                    assert.equal("hello", m.data);
-                    server.close(done);
-                }
-            });
-        };
-    });
+        es.onmessage = function (m) {
+          assert.equal("hello", m.data);
+          server.close(done);
+        }
+      });
+    };
+  });
 
-    it('is attempted when server goes down after connection', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('is attempted when server goes down after connection', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents(["data: hello\n\n"]));
-            var es = new EventSource(server.url);
-            es.reconnectInterval = 0;
+      server.on('request', writeEvents(["data: hello\n\n"]));
+      var es = new EventSource(server.url);
+      es.reconnectInterval = 0;
 
+      es.onmessage = function (m) {
+        assert.equal("hello", m.data);
+        server.close(function (err) {
+          if(err) return done(err);
+
+          var port = u.parse(es.url).port;
+          configureServer(http.createServer(), 'http', port, function (err, server2) {
+            if(err) return done(err);
+
+            server2.on('request', writeEvents(["data: world\n\n"]));
             es.onmessage = function (m) {
-                assert.equal("hello", m.data);
-                server.close(function (err) {
-                    if (err) return done(err);
-
-                    var port = u.parse(es.url).port;
-                    configureServer(http.createServer(), 'http', port, function (err, server2) {
-                        if (err) return done(err);
-
-                        server2.on('request', writeEvents(["data: world\n\n"]));
-                        es.onmessage = function (m) {
-                            assert.equal("world", m.data);
-                            server2.close(done);
-                        };
-                    });
-                });
+              assert.equal("world", m.data);
+              server2.close(done);
             };
+          });
         });
+      };
     });
+  });
 
-    it('is stopped when server goes down and eventsource is being closed', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('is stopped when server goes down and eventsource is being closed', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents(["data: hello\n\n"]));
-            var es = new EventSource(server.url);
-            es.reconnectInterval = 0;
+      server.on('request', writeEvents(["data: hello\n\n"]));
+      var es = new EventSource(server.url);
+      es.reconnectInterval = 0;
 
-            es.onmessage = function (m) {
-                assert.equal("hello", m.data);
-                server.close(function (err) {
-                    if (err) return done(err);
-                    // The server has closed down. es.onerror should now get called,
-                    // because es's remote connection was dropped.
-                });
-            };
-
-            es.onerror = function () {
-                // We received an error because the remote connection was closed.
-                // We close es, so we do not want es to reconnect.
-                es.close();
-
-                var port = u.parse(es.url).port;
-                configureServer(http.createServer(), 'http', port, function (err, server2) {
-                    if (err) return done(err);
-                    server2.on('request', writeEvents(["data: world\n\n"]));
-
-                    es.onmessage = function (m) {
-                        return done(new Error("Unexpected message: " + m.data));
-                    };
-
-                    setTimeout(function () {
-                        // We have not received any message within 100ms, we can
-                        // presume this works correctly.
-                        server2.close(done);
-                    }, 100);
-                });
-            };
+      es.onmessage = function (m) {
+        assert.equal("hello", m.data);
+        server.close(function (err) {
+          if(err) return done(err);
+          // The server has closed down. es.onerror should now get called,
+          // because es's remote connection was dropped.
         });
+      };
+
+      es.onerror = function () {
+        // We received an error because the remote connection was closed.
+        // We close es, so we do not want es to reconnect.
+        es.close();
+
+        var port = u.parse(es.url).port;
+        configureServer(http.createServer(), 'http', port, function (err, server2) {
+          if(err) return done(err);
+          server2.on('request', writeEvents(["data: world\n\n"]));
+
+          es.onmessage = function (m) {
+            return done(new Error("Unexpected message: " + m.data));
+          };
+
+          setTimeout(function () {
+            // We have not received any message within 100ms, we can
+            // presume this works correctly.
+            server2.close(done);
+          }, 100);
+        });
+      };
     });
+  });
 
-    it('is not attempted when server responds with HTTP 204', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('is not attempted when server responds with HTTP 204', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', function (req, res) {
-                res.writeHead(204);
-                res.end();
+      server.on('request', function (req, res) {
+        res.writeHead(204);
+        res.end();
+      });
+
+      var es = new EventSource(server.url);
+      es.reconnectInterval = 0;
+
+      es.onerror = function (e) {
+        assert.equal(e.status, 204);
+        server.close(function (err) {
+          if(err) return done(err);
+
+          var port = u.parse(es.url).port;
+          configureServer(http.createServer(), 'http', port, function (err, server2) {
+            if(err) return done(err);
+
+            // this will be verified by the readyState
+            // going from CONNECTING to CLOSED,
+            // along with the tests verifying that the
+            // state is CONNECTING when a server closes.
+            // it's next to impossible to write a fail-safe
+            // test for this, though.
+            var ival = setInterval(function () {
+              if (es.readyState == EventSource.CLOSED) {
+                clearInterval(ival);
+                server2.close(done);
+              }
+            }, 5);
+          });
+        });
+      };
+    });
+  });
+
+  it('sends Last-Event-ID http header when it has previously been passed in an event from the server', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
+
+      server.on('request', writeEvents(['id: 10\ndata: Hello\n\n']));
+
+      var es = new EventSource(server.url);
+      es.reconnectInterval = 0;
+
+      es.onmessage = function () {
+        server.close(function (err) {
+          if(err) return done(err);
+
+          var port = u.parse(es.url).port;
+          configureServer(http.createServer(), 'http', port, function (err, server2) {
+            server2.on('request', function (req, res) {
+              assert.equal('10', req.headers['last-event-id']);
+              server2.close(done);
             });
-
-            var es = new EventSource(server.url);
-            es.reconnectInterval = 0;
-
-            es.onerror = function (e) {
-                assert.equal(e.status, 204);
-                server.close(function (err) {
-                    if (err) return done(err);
-
-                    var port = u.parse(es.url).port;
-                    configureServer(http.createServer(), 'http', port, function (err, server2) {
-                        if (err) return done(err);
-
-                        // this will be verified by the readyState
-                        // going from CONNECTING to CLOSED,
-                        // along with the tests verifying that the
-                        // state is CONNECTING when a server closes.
-                        // it's next to impossible to write a fail-safe
-                        // test for this, though.
-                        var ival = setInterval(function () {
-                            if (es.readyState == EventSource.CLOSED) {
-                                clearInterval(ival);
-                                server2.close(done);
-                            }
-                        }, 5);
-                    });
-                });
-            };
+          });
         });
+      };
     });
+  });
 
-    it('sends Last-Event-ID http header when it has previously been passed in an event from the server', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('sends correct Last-Event-ID http header when an initial Last-Event-ID header was specified in the constructor', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents(['id: 10\ndata: Hello\n\n']));
+      server.on('request', function (req, res) {
+        assert.equal('9', req.headers['last-event-id']);
+        server.close(done);
+      });
 
-            var es = new EventSource(server.url);
-            es.reconnectInterval = 0;
-
-            es.onmessage = function () {
-                server.close(function (err) {
-                    if (err) return done(err);
-
-                    var port = u.parse(es.url).port;
-                    configureServer(http.createServer(), 'http', port, function (err, server2) {
-                        server2.on('request', function (req, res) {
-                            assert.equal('10', req.headers['last-event-id']);
-                            server2.close(done);
-                        });
-                    });
-                });
-            };
-        });
+      new EventSource(server.url, {headers: {'Last-Event-ID': '9'}});
     });
+  });
 
-    it('sends correct Last-Event-ID http header when an initial Last-Event-ID header was specified in the constructor', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('does not send Last-Event-ID http header when it has not been previously sent by the server', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', function (req, res) {
-                assert.equal('9', req.headers['last-event-id']);
-                server.close(done);
+      server.on('request', writeEvents(['data: Hello\n\n']));
+
+      var es = new EventSource(server.url);
+      es.reconnectInterval = 0;
+
+      es.onmessage = function () {
+        server.close(function (err) {
+          if(err) return done(err);
+
+          var port = u.parse(es.url).port;
+          configureServer(http.createServer(), 'http', port, function (err, server2) {
+            server2.on('request', function (req, res) {
+              assert.equal(undefined, req.headers['last-event-id']);
+              server2.close(done);
             });
-
-            new EventSource(server.url, {headers: {'Last-Event-ID': '9'}});
+          });
         });
+      };
     });
-
-    it('does not send Last-Event-ID http header when it has not been previously sent by the server', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
-
-            server.on('request', writeEvents(['data: Hello\n\n']));
-
-            var es = new EventSource(server.url);
-            es.reconnectInterval = 0;
-
-            es.onmessage = function () {
-                server.close(function (err) {
-                    if (err) return done(err);
-
-                    var port = u.parse(es.url).port;
-                    configureServer(http.createServer(), 'http', port, function (err, server2) {
-                        server2.on('request', function (req, res) {
-                            assert.equal(undefined, req.headers['last-event-id']);
-                            server2.close(done);
-                        });
-                    });
-                });
-            };
-        });
-    });
+  });
 });
 
 describe('readyState', function () {
-    it('has CONNECTING constant', function () {
-        assert.equal(0, EventSource.CONNECTING);
-    });
+  it('has CONNECTING constant', function () {
+    assert.equal(0, EventSource.CONNECTING);
+  });
 
-    it('has OPEN constant', function () {
-        assert.equal(1, EventSource.OPEN);
-    });
+  it('has OPEN constant', function () {
+    assert.equal(1, EventSource.OPEN);
+  });
 
-    it('has CLOSED constant', function () {
-        assert.equal(2, EventSource.CLOSED);
-    });
+  it('has CLOSED constant', function () {
+    assert.equal(2, EventSource.CLOSED);
+  });
 
-    it('is CONNECTING before connection has been established', function (done) {
-        var es = new EventSource('http://localhost:' + _port);
-        assert.equal(EventSource.CONNECTING, es.readyState);
-        es.onerror = function () {
-            es.close();
+  it('is CONNECTING before connection has been established', function (done) {
+    var es = new EventSource('http://localhost:' + _port);
+    assert.equal(EventSource.CONNECTING, es.readyState);
+    es.onerror = function () {
+      es.close();
+      done();
+    }
+  });
+
+  it('is CONNECTING when server has closed the connection', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
+
+      server.on('request', writeEvents([]));
+      var es = new EventSource(server.url);
+      es.reconnectInterval = 0;
+
+      es.onopen = function (m) {
+        server.close(function (err) {
+          if(err) return done(err);
+
+          es.onerror = function () {
+            es.onerror = null;
+            assert.equal(EventSource.CONNECTING, es.readyState);
             done();
-        }
-    });
-
-    it('is CONNECTING when server has closed the connection', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
-
-            server.on('request', writeEvents([]));
-            var es = new EventSource(server.url);
-            es.reconnectInterval = 0;
-
-            es.onopen = function (m) {
-                server.close(function (err) {
-                    if (err) return done(err);
-
-                    es.onerror = function () {
-                        es.onerror = null;
-                        assert.equal(EventSource.CONNECTING, es.readyState);
-                        done();
-                    };
-                });
-            };
+          };
         });
+      };
     });
+  });
 
-    it('is OPEN when connection has been established', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('is OPEN when connection has been established', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents([]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents([]));
+      var es = new EventSource(server.url);
 
-            es.onopen = function () {
-                assert.equal(EventSource.OPEN, es.readyState);
-                server.close(done);
-            }
-        });
+      es.onopen = function () {
+        assert.equal(EventSource.OPEN, es.readyState);
+        server.close(done);
+      }
     });
+  });
 
-    it('is CLOSED after connection has been closed', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('is CLOSED after connection has been closed', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents([]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents([]));
+      var es = new EventSource(server.url);
 
-            es.onopen = function () {
-                es.close();
-                assert.equal(EventSource.CLOSED, es.readyState);
-                server.close(done);
-            }
-        });
+      es.onopen = function () {
+        es.close();
+        assert.equal(EventSource.CLOSED, es.readyState);
+        server.close(done);
+      }
     });
+  });
 });
 
 describe('Properties', function () {
-    it('url exposes original request url', function () {
-        var url = 'http://localhost:' + _port;
-        var es = new EventSource(url);
-        assert.equal(url, es.url);
-    });
+  it('url exposes original request url', function () {
+    var url = 'http://localhost:' + _port;
+    var es = new EventSource(url);
+    assert.equal(url, es.url);
+  });
 });
 
 describe('Events', function () {
-    it('calls onopen when connection is established', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('calls onopen when connection is established', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents([]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents([]));
+      var es = new EventSource(server.url);
 
-            es.onopen = function (event) {
-                assert.equal(event.type, 'open');
-                server.close(done);
-            }
-        });
+      es.onopen = function (event) {
+        assert.equal(event.type, 'open');
+        server.close(done);
+      }
     });
+  });
 
-    it('supplies the correct origin', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('supplies the correct origin', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents(["data: hello\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["data: hello\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = function (event) {
-                assert.equal(event.origin, server.url);
-                server.close(done);
-            }
-        });
+      es.onmessage = function (event) {
+        assert.equal(event.origin, server.url);
+        server.close(done);
+      }
     });
+  });
 
-    it('emits open event when connection is established', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('emits open event when connection is established', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents([]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents([]));
+      var es = new EventSource(server.url);
 
-            es.addEventListener('open', function (event) {
-                assert.equal(event.type, 'open');
-                server.close(done);
-            });
-        });
+      es.addEventListener('open', function (event) {
+        assert.equal(event.type, 'open');
+        server.close(done);
+      });
     });
+  });
 
-    it('does not emit error when connection is closed by client', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('does not emit error when connection is closed by client', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents([]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents([]));
+      var es = new EventSource(server.url);
 
-            es.addEventListener('open', function () {
-                es.close();
-                process.nextTick(function () {
-                    server.close(done);
-                });
-            });
-            es.addEventListener('error', function () {
-                done(new Error('error should not be emitted'));
-            });
+      es.addEventListener('open', function () {
+        es.close();
+        process.nextTick(function () {
+          server.close(done);
         });
+      });
+      es.addEventListener('error', function () {
+        done(new Error('error should not be emitted'));
+      });
     });
+  });
 
-    it('populates message\'s lastEventId correctly when the last event has an associated id', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('populates message\'s lastEventId correctly when the last event has an associated id', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents(["id: 123\ndata: hello\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["id: 123\ndata: hello\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = function (m) {
-                assert.equal(m.lastEventId, "123");
-                server.close(done);
-            };
-        });
+      es.onmessage = function (m) {
+        assert.equal(m.lastEventId, "123");
+        server.close(done);
+      };
     });
+  });
 
-    it('populates message\'s lastEventId correctly when the last event doesn\'t have an associated id', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('populates message\'s lastEventId correctly when the last event doesn\'t have an associated id', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents(["id: 123\ndata: Hello\n\n", "data: World\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["id: 123\ndata: Hello\n\n", "data: World\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = first;
+      es.onmessage = first;
 
-            function first() {
-                es.onmessage = second;
-            }
+      function first() {
+        es.onmessage = second;
+      }
 
-            function second(m) {
-                assert.equal(m.data, "World");
-                assert.equal(m.lastEventId, "123");  //expect to get back the previous event id
-                server.close(done);
-            }
-        });
+      function second(m) {
+        assert.equal(m.data, "World");
+        assert.equal(m.lastEventId, "123");  //expect to get back the previous event id
+        server.close(done);
+      }
     });
+  });
 
-    it('populates messages with enumerable properties so they can be inspected via console.log().', function (done) {
-        createServer(function (err, server) {
-            if (err) return done(err);
+  it('populates messages with enumerable properties so they can be inspected via console.log().', function (done) {
+    createServer(function (err, server) {
+      if(err) return done(err);
 
-            server.on('request', writeEvents(["data: World\n\n"]));
-            var es = new EventSource(server.url);
+      server.on('request', writeEvents(["data: World\n\n"]));
+      var es = new EventSource(server.url);
 
-            es.onmessage = function (m) {
-                var enumerableAttributes = Object.keys(m);
-                assert.notEqual(enumerableAttributes.indexOf("data"), -1);
-                assert.notEqual(enumerableAttributes.indexOf("type"), -1);
-                server.close(done);
-            };
-        });
+      es.onmessage = function (m) {
+        var enumerableAttributes = Object.keys(m);
+        assert.notEqual(enumerableAttributes.indexOf("data"), -1);
+        assert.notEqual(enumerableAttributes.indexOf("type"), -1);
+        server.close(done);
+      };
     });
+  });
 });

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -1,875 +1,888 @@
 var EventSource = require('../lib/eventsource')
-  , http = require('http')
-  , https = require('https')
-  , fs = require('fs')
-  , assert = require('assert')
-  , u = require('url');
+    , http = require('http')
+    , https = require('https')
+    , fs = require('fs')
+    , assert = require('assert')
+    , u = require('url');
 
 var _port = 20000;
 var servers = 0;
 process.on('exit', function () {
-  if (servers != 0) {
-    console.error("************ Didn't kill all servers - there is still %d running.", servers);
-  }
+    if (servers != 0) {
+        console.error("************ Didn't kill all servers - there is still %d running.", servers);
+    }
 });
 
 function createServer(callback) {
-  var server = http.createServer();
-  configureServer(server, 'http', _port++, callback);
+    var server = http.createServer();
+    configureServer(server, 'http', _port++, callback);
 }
 
 function createHttpsServer(callback) {
-  var options = {
-    key: fs.readFileSync(__dirname + '/key.pem'),
-    cert: fs.readFileSync(__dirname + '/certificate.pem')
-  };
-  var server = https.createServer(options);
-  configureServer(server, 'https', _port++, callback);
+    var options = {
+        key: fs.readFileSync(__dirname + '/key.pem'),
+        cert: fs.readFileSync(__dirname + '/certificate.pem')
+    };
+    var server = https.createServer(options);
+    configureServer(server, 'https', _port++, callback);
 }
 
 function configureServer(server, protocol, port, callback) {
-  var responses = [];
+    var responses = [];
 
-  var oldClose = server.close;
-  server.close = function() {
-    responses.forEach(function (res) {
-      res.end();
+    var oldClose = server.close;
+    server.close = function () {
+        responses.forEach(function (res) {
+            res.end();
+        });
+        servers--;
+        oldClose.apply(this, arguments);
+    };
+
+    server.on('request', function (req, res) {
+        responses.push(res);
     });
-    servers--;
-    oldClose.apply(this, arguments);
-  };
 
-  server.on('request', function (req, res) {
-    responses.push(res);
-  });
+    server.url = protocol + '://localhost:' + port;
 
-  server.url = protocol + '://localhost:' + port;
-
-  server.listen(port, function onOpen(err) {
-    servers++;
-    callback(err, server);
-  });
+    server.listen(port, function onOpen(err) {
+        servers++;
+        callback(err, server);
+    });
 }
 
 function writeEvents(chunks) {
-  return function (req, res) {
-    res.writeHead(200, {'Content-Type': 'text/event-stream'});
-    chunks.forEach(function (chunk) {
-      res.write(chunk);
-    });
-    res.write(':'); // send a dummy comment to ensure that the head is flushed
-  };
+    return function (req, res) {
+        res.writeHead(200, {'Content-Type': 'text/event-stream'});
+        chunks.forEach(function (chunk) {
+            res.write(chunk);
+        });
+        res.write(':'); // send a dummy comment to ensure that the head is flushed
+    };
 }
 
 describe('Parser', function () {
-  it('parses multibyte characters', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('parses multibyte characters', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["id: 1\ndata: €豆腐\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents(["id: 1\ndata: €豆腐\n\n"]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = function (m) {
-        assert.equal("€豆腐", m.data);
-        server.close(done);
-      };
+            es.onmessage = function (m) {
+                assert.equal("€豆腐", m.data);
+                server.close(done);
+            };
+        });
     });
-  });
 
-  it('parses empty lines with multibyte characters', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('parses empty lines with multibyte characters', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["\n\n\n\nid: 1\ndata: 我現在都看實況不玩遊戲\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents(["\n\n\n\nid: 1\ndata: 我現在都看實況不玩遊戲\n\n"]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = function (m) {
-        assert.equal("我現在都看實況不玩遊戲", m.data);
-        server.close(done);
-      };
+            es.onmessage = function (m) {
+                assert.equal("我現在都看實況不玩遊戲", m.data);
+                server.close(done);
+            };
+        });
     });
-  });
 
-  it('parses one one-line message in one chunk', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('parses one one-line message in one chunk', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: Hello\n\n"]));
-      var es = new EventSource(server.url);
-      es.onmessage = function (m) {
-        assert.equal("Hello", m.data);
-        server.close(done);
-      };
+            server.on('request', writeEvents(["data: Hello\n\n"]));
+            var es = new EventSource(server.url);
+            es.onmessage = function (m) {
+                assert.equal("Hello", m.data);
+                server.close(done);
+            };
+        });
     });
-  });
 
-  it('parses one one-line message in two chunks', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('parses one one-line message in two chunks', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: Hel", "lo\n\n"]));
-      var es = new EventSource(server.url);
-      es.onmessage = function (m) {
-        assert.equal("Hello", m.data);
-        server.close(done);
-      };
+            server.on('request', writeEvents(["data: Hel", "lo\n\n"]));
+            var es = new EventSource(server.url);
+            es.onmessage = function (m) {
+                assert.equal("Hello", m.data);
+                server.close(done);
+            };
+        });
     });
-  });
 
-  it('parses two one-line messages in one chunk', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('parses two one-line messages in one chunk', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: Hello\n\n", "data: World\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents(["data: Hello\n\n", "data: World\n\n"]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = first;
+            es.onmessage = first;
 
-      function first(m) {
-        assert.equal("Hello", m.data);
-        es.onmessage = second;
-      }
+            function first(m) {
+                assert.equal("Hello", m.data);
+                es.onmessage = second;
+            }
 
-      function second(m) {
-        assert.equal("World", m.data);
-        server.close(done);
-      }
+            function second(m) {
+                assert.equal("World", m.data);
+                server.close(done);
+            }
+        });
     });
-  });
 
-  it('parses one two-line message in one chunk', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('parses one two-line message in one chunk', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: Hello\ndata:World\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents(["data: Hello\ndata:World\n\n"]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = function (m) {
-        assert.equal("Hello\nWorld", m.data);
-        server.close(done);
-      };
+            es.onmessage = function (m) {
+                assert.equal("Hello\nWorld", m.data);
+                server.close(done);
+            };
+        });
     });
-  });
 
-  it('parses really chopped up unicode data', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('parses really chopped up unicode data', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      var chopped = "data: Aslak\n\ndata: Hellesøy\n\n".split("");
-      server.on('request', writeEvents(chopped));
-      var es = new EventSource(server.url);
+            var chopped = "data: Aslak\n\ndata: Hellesøy\n\n".split("");
+            server.on('request', writeEvents(chopped));
+            var es = new EventSource(server.url);
 
-      es.onmessage = first;
+            es.onmessage = first;
 
-      function first(m) {
-        assert.equal("Aslak", m.data);
-        es.onmessage = second;
-      }
+            function first(m) {
+                assert.equal("Aslak", m.data);
+                es.onmessage = second;
+            }
 
-      function second(m) {
-        assert.equal("Hellesøy", m.data);
-        server.close(done);
-      }
+            function second(m) {
+                assert.equal("Hellesøy", m.data);
+                server.close(done);
+            }
+        });
     });
-  });
 
-  it('accepts CRLF as separator', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('accepts CRLF as separator', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      var chopped = "data: Aslak\r\n\r\ndata: Hellesøy\r\n\r\n".split("");
-      server.on('request', writeEvents(chopped));
-      var es = new EventSource(server.url);
+            var chopped = "data: Aslak\r\n\r\ndata: Hellesøy\r\n\r\n".split("");
+            server.on('request', writeEvents(chopped));
+            var es = new EventSource(server.url);
 
-      es.onmessage = first;
+            es.onmessage = first;
 
-      function first(m) {
-        assert.equal("Aslak", m.data);
-        es.onmessage = second;
-      }
+            function first(m) {
+                assert.equal("Aslak", m.data);
+                es.onmessage = second;
+            }
 
-      function second(m) {
-        assert.equal("Hellesøy", m.data);
-        server.close(done);
-      }
+            function second(m) {
+                assert.equal("Hellesøy", m.data);
+                server.close(done);
+            }
+        });
     });
-  });
 
-  it('accepts CR as separator', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('accepts CR as separator', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      var chopped = "data: Aslak\r\rdata: Hellesøy\r\r".split("");
-      server.on('request', writeEvents(chopped));
-      var es = new EventSource(server.url);
+            var chopped = "data: Aslak\r\rdata: Hellesøy\r\r".split("");
+            server.on('request', writeEvents(chopped));
+            var es = new EventSource(server.url);
 
-      es.onmessage = first;
+            es.onmessage = first;
 
-      function first(m) {
-        assert.equal("Aslak", m.data);
-        es.onmessage = second;
-      }
+            function first(m) {
+                assert.equal("Aslak", m.data);
+                es.onmessage = second;
+            }
 
-      function second(m) {
-        assert.equal("Hellesøy", m.data);
-        server.close(done);
-      }
+            function second(m) {
+                assert.equal("Hellesøy", m.data);
+                server.close(done);
+            }
+        });
     });
-  });
 
-  it('delivers message with explicit event', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
-
-      server.on('request', writeEvents(["event: greeting\ndata: Hello\n\n"]));
-      var es = new EventSource(server.url);
-
-      es.addEventListener('greeting', function (m) {
-        assert.equal("Hello", m.data);
-        server.close(done);
-      });
+    it('raises an event with a specific key when a message has the event set', function (done) {
+        raiseEventAndCheck('greeting','greeting', done);
     });
-  });
 
-  it('ignores comments', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
-
-      server.on('request', writeEvents(["data: Hello\n\n:nothing to see here\n\ndata: World\n\n"]));
-      var es = new EventSource(server.url);
-
-      es.onmessage = first;
-
-      function first(m) {
-        assert.equal("Hello", m.data);
-        es.onmessage = second;
-      }
-
-      function second(m) {
-        assert.equal("World", m.data);
-        server.close(done);
-      }
+    it('raises an event with a generic \'message\' key when a message has the event set', function (done) {
+        raiseEventAndCheck('greeting','message', done);
     });
-  });
 
-  it('ignores empty comments', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
-
-      server.on('request', writeEvents(["data: Hello\n\n:\n\ndata: World\n\n"]));
-      var es = new EventSource(server.url);
-
-      es.onmessage = first;
-
-      function first(m) {
-        assert.equal("Hello", m.data);
-        es.onmessage = second;
-      }
-
-      function second(m) {
-        assert.equal("World", m.data);
-        server.close(done);
-      }
+    it('raises an event with a generic \'message\' key when the event is not set', function (done) {
+        raiseEventAndCheck('','message', done);
     });
-  });
 
-  it('does not ignore multilines strings', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    function raiseEventAndCheck(sseEventKey, eventListenerKey, done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: line one\ndata:\ndata: line two\n\n"]));
-      var es = new EventSource(server.url);
+            var event = (sseEventKey ? "event: " + sseEventKey + "\n" : "") + "data: Hello\n\n";
+            server.on('request', writeEvents([event]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = function (m) {
-        assert.equal('line one\n\nline two', m.data);
-        server.close(done);
-      };
+            es.addEventListener(eventListenerKey, function (m) {
+                assert.equal("Hello", m.data);
+                server.close(done);
+            });
+        });
+    }
+
+    it('ignores comments', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
+
+            server.on('request', writeEvents(["data: Hello\n\n:nothing to see here\n\ndata: World\n\n"]));
+            var es = new EventSource(server.url);
+
+            es.onmessage = first;
+
+            function first(m) {
+                assert.equal("Hello", m.data);
+                es.onmessage = second;
+            }
+
+            function second(m) {
+                assert.equal("World", m.data);
+                server.close(done);
+            }
+        });
     });
-  });
 
-  it('does not ignore multilines strings even in data beginning', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('ignores empty comments', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data:\ndata:line one\ndata: line two\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents(["data: Hello\n\n:\n\ndata: World\n\n"]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = function (m) {
-        assert.equal('\nline one\nline two', m.data);
-        server.close(done);
-      };
+            es.onmessage = first;
+
+            function first(m) {
+                assert.equal("Hello", m.data);
+                es.onmessage = second;
+            }
+
+            function second(m) {
+                assert.equal("World", m.data);
+                server.close(done);
+            }
+        });
     });
-  });
 
-  it('causes entire event to be ignored for empty event field', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('does not ignore multilines strings', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["event:\n\ndata: Hello\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents(["data: line one\ndata:\ndata: line two\n\n"]));
+            var es = new EventSource(server.url);
 
-      var originalEmit = es.emit;
-      es.emit = function (event) {
-        assert.ok(event === 'message' || event === 'newListener');
-        return originalEmit.apply(this, arguments);
-      };
-      es.onmessage = function (m) {
-        assert.equal('Hello', m.data);
-        server.close(done);
-      };
+            es.onmessage = function (m) {
+                assert.equal('line one\n\nline two', m.data);
+                server.close(done);
+            };
+        });
     });
-  });
 
-  it('parses relatively huge messages efficiently', function (done) {
-    this.timeout(1000);
+    it('does not ignore multilines strings even in data beginning', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-    createServer(function (err, server) {
-      if (err) return done(err);
-      var longMessage = "data: " + new Array(100000).join('a') + "\n\n";
-      server.on('request', writeEvents([longMessage]));
+            server.on('request', writeEvents(["data:\ndata:line one\ndata: line two\n\n"]));
+            var es = new EventSource(server.url);
 
-      var es = new EventSource(server.url);
-
-      es.onmessage = function () {
-        server.close(done);
-      };
+            es.onmessage = function (m) {
+                assert.equal('\nline one\nline two', m.data);
+                server.close(done);
+            };
+        });
     });
-  });
+
+    it('causes entire event to be ignored for empty event field', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
+
+            server.on('request', writeEvents(["event:\n\ndata: Hello\n\n"]));
+            var es = new EventSource(server.url);
+
+            var originalEmit = es.emit;
+            es.emit = function (event) {
+                assert.ok(event === 'message' || event === 'newListener');
+                return originalEmit.apply(this, arguments);
+            };
+            es.onmessage = function (m) {
+                assert.equal('Hello', m.data);
+                server.close(done);
+            };
+        });
+    });
+
+    it('parses relatively huge messages efficiently', function (done) {
+        this.timeout(1000);
+
+        createServer(function (err, server) {
+            if (err) return done(err);
+            var longMessage = "data: " + new Array(100000).join('a') + "\n\n";
+            server.on('request', writeEvents([longMessage]));
+
+            var es = new EventSource(server.url);
+
+            es.onmessage = function () {
+                server.close(done);
+            };
+        });
+    });
 });
 
 describe('HTTP Request', function () {
-  it('passes cache-control: no-cache to server', function (done) {
-    createServer(function (err, server) {
-      if (err) return done(err);
+    it('passes cache-control: no-cache to server', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', function (req) {
-        assert.equal('no-cache', req.headers['cache-control']);
-        server.close(done);
-      });
-      new EventSource(server.url);
-    });
-  });
-
-  it('sets request headers', function (done) {
-    var server = createServer(function (err, server) {
-      if (err) return done(err);
-
-      server.on('request', function (req) {
-        assert.equal(req.headers['user-agent'], 'test');
-        assert.equal(req.headers['cookie'], 'test=test');
-        assert.equal(req.headers['last-event-id'], '99');
-        server.close(done);
-      });
-
-      var headers = {
-        'User-Agent': 'test',
-        'Cookie': 'test=test',
-        'Last-Event-ID': '99'
-      };
-      new EventSource(server.url, {headers: headers});
-    });
-  });
-
-  it("does not set request headers that don't have a value", function (done) {
-    var server = createServer(function (err, server) {
-      if (err) return done(err);
-
-      server.on('request', function (req) {
-        assert.equal(req.headers['user-agent'], 'test');
-        assert.equal(req.headers['cookie'], 'test=test');
-        assert.equal(req.headers['last-event-id'], '99');
-        assert.equal(req.headers['X-Something'], undefined);
-        server.close(done);
-      });
-
-      var headers = {
-        'User-Agent': 'test',
-        'Cookie': 'test=test',
-        'Last-Event-ID': '99',
-        'X-Something': null
-      };
-
-      assert.doesNotThrow(
-        function() {
-          new EventSource(server.url, {headers: headers});
-        }
-      );
-    });
-  });
-
-  [301, 307].forEach(function (status) {
-    it('follows http ' + status + ' redirect', function (done) {
-      var redirectSuffix = '/foobar';
-      var clientRequestedRedirectUrl = false;
-      createServer(function (err, server) {
-        if(err) return done(err);
-
-        server.on('request', function (req, res) {
-          if (req.url === '/') {
-            res.writeHead(status, {
-              'Connection': 'Close',
-              'Location': server.url + redirectSuffix
+            server.on('request', function (req) {
+                assert.equal('no-cache', req.headers['cache-control']);
+                server.close(done);
             });
-            res.end();
-          } else if (req.url === redirectSuffix) {
-            clientRequestedRedirectUrl = true;
-            res.writeHead(200, {'Content-Type': 'text/event-stream'});
-            res.end();
-          }
+            new EventSource(server.url);
         });
-
-        var es = new EventSource(server.url);
-        es.onopen = function () {
-          assert.ok(clientRequestedRedirectUrl);
-          assert.equal(server.url + redirectSuffix, es.url);
-          server.close(done);
-        };
-      });
     });
 
+    it('sets request headers', function (done) {
+        var server = createServer(function (err, server) {
+            if (err) return done(err);
 
-    it('causes error event when response is ' + status + ' with missing location', function (done) {
-      var redirectSuffix = '/foobar';
-      var clientRequestedRedirectUrl = false;
-      createServer(function (err, server) {
-        if(err) return done(err);
+            server.on('request', function (req) {
+                assert.equal(req.headers['user-agent'], 'test');
+                assert.equal(req.headers['cookie'], 'test=test');
+                assert.equal(req.headers['last-event-id'], '99');
+                server.close(done);
+            });
 
-        server.on('request', function (req, res) {
-          res.writeHead(status, {
-            'Connection': 'Close'
-          });
-          res.end();
+            var headers = {
+                'User-Agent': 'test',
+                'Cookie': 'test=test',
+                'Last-Event-ID': '99'
+            };
+            new EventSource(server.url, {headers: headers});
+        });
+    });
+
+    it("does not set request headers that don't have a value", function (done) {
+        var server = createServer(function (err, server) {
+            if (err) return done(err);
+
+            server.on('request', function (req) {
+                assert.equal(req.headers['user-agent'], 'test');
+                assert.equal(req.headers['cookie'], 'test=test');
+                assert.equal(req.headers['last-event-id'], '99');
+                assert.equal(req.headers['X-Something'], undefined);
+                server.close(done);
+            });
+
+            var headers = {
+                'User-Agent': 'test',
+                'Cookie': 'test=test',
+                'Last-Event-ID': '99',
+                'X-Something': null
+            };
+
+            assert.doesNotThrow(
+                function () {
+                    new EventSource(server.url, {headers: headers});
+                }
+            );
+        });
+    });
+
+    [301, 307].forEach(function (status) {
+        it('follows http ' + status + ' redirect', function (done) {
+            var redirectSuffix = '/foobar';
+            var clientRequestedRedirectUrl = false;
+            createServer(function (err, server) {
+                if (err) return done(err);
+
+                server.on('request', function (req, res) {
+                    if (req.url === '/') {
+                        res.writeHead(status, {
+                            'Connection': 'Close',
+                            'Location': server.url + redirectSuffix
+                        });
+                        res.end();
+                    } else if (req.url === redirectSuffix) {
+                        clientRequestedRedirectUrl = true;
+                        res.writeHead(200, {'Content-Type': 'text/event-stream'});
+                        res.end();
+                    }
+                });
+
+                var es = new EventSource(server.url);
+                es.onopen = function () {
+                    assert.ok(clientRequestedRedirectUrl);
+                    assert.equal(server.url + redirectSuffix, es.url);
+                    server.close(done);
+                };
+            });
         });
 
-        var es = new EventSource(server.url);
-        es.onerror = function (err) {
-          assert.equal(err.status, status);
-          server.close(done);
-        };
-      });
-    });
-  });
 
-  [401, 403].forEach(function (status) {
-    it('causes error event when response status is ' + status, function (done) {
-      createServer(function (err, server) {
-        if(err) return done(err);
+        it('causes error event when response is ' + status + ' with missing location', function (done) {
+            var redirectSuffix = '/foobar';
+            var clientRequestedRedirectUrl = false;
+            createServer(function (err, server) {
+                if (err) return done(err);
 
-        server.on('request', function (req, res) {
-          res.writeHead(status, {'Content-Type': 'text/html'});
-          res.end();
+                server.on('request', function (req, res) {
+                    res.writeHead(status, {
+                        'Connection': 'Close'
+                    });
+                    res.end();
+                });
+
+                var es = new EventSource(server.url);
+                es.onerror = function (err) {
+                    assert.equal(err.status, status);
+                    server.close(done);
+                };
+            });
         });
-
-        var es = new EventSource(server.url);
-        es.onerror = function (err) {
-          assert.equal(err.status, status);
-          server.close(done);
-        };
-      });
     });
-  });
+
+    [401, 403].forEach(function (status) {
+        it('causes error event when response status is ' + status, function (done) {
+            createServer(function (err, server) {
+                if (err) return done(err);
+
+                server.on('request', function (req, res) {
+                    res.writeHead(status, {'Content-Type': 'text/html'});
+                    res.end();
+                });
+
+                var es = new EventSource(server.url);
+                es.onerror = function (err) {
+                    assert.equal(err.status, status);
+                    server.close(done);
+                };
+            });
+        });
+    });
 });
 
 describe('HTTPS Support', function () {
-  it('uses https for https urls', function (done) {
-    createHttpsServer(function (err, server) {
-      if(err) return done(err);
+    it('uses https for https urls', function (done) {
+        createHttpsServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: hello\n\n"]));
-      var es = new EventSource(server.url, {rejectUnauthorized: false});
+            server.on('request', writeEvents(["data: hello\n\n"]));
+            var es = new EventSource(server.url, {rejectUnauthorized: false});
 
-      es.onmessage = function (m) {
-        assert.equal("hello", m.data);
-        server.close(done);
-      }
+            es.onmessage = function (m) {
+                assert.equal("hello", m.data);
+                server.close(done);
+            }
+        });
     });
-  });
 });
 
 describe('Reconnection', function () {
-  it('is attempted when server is down', function (done) {
-    var es = new EventSource('http://localhost:' + _port);
-    es.reconnectInterval = 0;
+    it('is attempted when server is down', function (done) {
+        var es = new EventSource('http://localhost:' + _port);
+        es.reconnectInterval = 0;
 
-    es.onerror = function () {
-      es.onerror = null;
-      createServer(function (err, server) {
-        if(err) return done(err);
+        es.onerror = function () {
+            es.onerror = null;
+            createServer(function (err, server) {
+                if (err) return done(err);
 
-        server.on('request', writeEvents(["data: hello\n\n"]));
+                server.on('request', writeEvents(["data: hello\n\n"]));
 
-        es.onmessage = function (m) {
-          assert.equal("hello", m.data);
-          server.close(done);
-        }
-      });
-    };
-  });
+                es.onmessage = function (m) {
+                    assert.equal("hello", m.data);
+                    server.close(done);
+                }
+            });
+        };
+    });
 
-  it('is attempted when server goes down after connection', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('is attempted when server goes down after connection', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: hello\n\n"]));
-      var es = new EventSource(server.url);
-      es.reconnectInterval = 0;
+            server.on('request', writeEvents(["data: hello\n\n"]));
+            var es = new EventSource(server.url);
+            es.reconnectInterval = 0;
 
-      es.onmessage = function (m) {
-        assert.equal("hello", m.data);
-        server.close(function (err) {
-          if(err) return done(err);
-
-          var port = u.parse(es.url).port;
-          configureServer(http.createServer(), 'http', port, function (err, server2) {
-            if(err) return done(err);
-
-            server2.on('request', writeEvents(["data: world\n\n"]));
             es.onmessage = function (m) {
-              assert.equal("world", m.data);
-              server2.close(done);
+                assert.equal("hello", m.data);
+                server.close(function (err) {
+                    if (err) return done(err);
+
+                    var port = u.parse(es.url).port;
+                    configureServer(http.createServer(), 'http', port, function (err, server2) {
+                        if (err) return done(err);
+
+                        server2.on('request', writeEvents(["data: world\n\n"]));
+                        es.onmessage = function (m) {
+                            assert.equal("world", m.data);
+                            server2.close(done);
+                        };
+                    });
+                });
             };
-          });
         });
-      };
     });
-  });
 
-  it('is stopped when server goes down and eventsource is being closed', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('is stopped when server goes down and eventsource is being closed', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: hello\n\n"]));
-      var es = new EventSource(server.url);
-      es.reconnectInterval = 0;
+            server.on('request', writeEvents(["data: hello\n\n"]));
+            var es = new EventSource(server.url);
+            es.reconnectInterval = 0;
 
-      es.onmessage = function (m) {
-        assert.equal("hello", m.data);
-        server.close(function (err) {
-          if(err) return done(err);
-          // The server has closed down. es.onerror should now get called,
-          // because es's remote connection was dropped.
+            es.onmessage = function (m) {
+                assert.equal("hello", m.data);
+                server.close(function (err) {
+                    if (err) return done(err);
+                    // The server has closed down. es.onerror should now get called,
+                    // because es's remote connection was dropped.
+                });
+            };
+
+            es.onerror = function () {
+                // We received an error because the remote connection was closed.
+                // We close es, so we do not want es to reconnect.
+                es.close();
+
+                var port = u.parse(es.url).port;
+                configureServer(http.createServer(), 'http', port, function (err, server2) {
+                    if (err) return done(err);
+                    server2.on('request', writeEvents(["data: world\n\n"]));
+
+                    es.onmessage = function (m) {
+                        return done(new Error("Unexpected message: " + m.data));
+                    };
+
+                    setTimeout(function () {
+                        // We have not received any message within 100ms, we can
+                        // presume this works correctly.
+                        server2.close(done);
+                    }, 100);
+                });
+            };
         });
-      };
-
-      es.onerror = function () {
-        // We received an error because the remote connection was closed.
-        // We close es, so we do not want es to reconnect.
-        es.close();
-
-        var port = u.parse(es.url).port;
-        configureServer(http.createServer(), 'http', port, function (err, server2) {
-          if(err) return done(err);
-          server2.on('request', writeEvents(["data: world\n\n"]));
-
-          es.onmessage = function (m) {
-            return done(new Error("Unexpected message: " + m.data));
-          };
-
-          setTimeout(function () {
-            // We have not received any message within 100ms, we can
-            // presume this works correctly.
-            server2.close(done);
-          }, 100);
-        });
-      };
     });
-  });
 
-  it('is not attempted when server responds with HTTP 204', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('is not attempted when server responds with HTTP 204', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', function (req, res) {
-        res.writeHead(204);
-        res.end();
-      });
-
-      var es = new EventSource(server.url);
-      es.reconnectInterval = 0;
-
-      es.onerror = function (e) {
-        assert.equal(e.status, 204);
-        server.close(function (err) {
-          if(err) return done(err);
-
-          var port = u.parse(es.url).port;
-          configureServer(http.createServer(), 'http', port, function (err, server2) {
-            if(err) return done(err);
-
-            // this will be verified by the readyState
-            // going from CONNECTING to CLOSED,
-            // along with the tests verifying that the
-            // state is CONNECTING when a server closes.
-            // it's next to impossible to write a fail-safe
-            // test for this, though.
-            var ival = setInterval(function () {
-              if (es.readyState == EventSource.CLOSED) {
-                clearInterval(ival);
-                server2.close(done);
-              }
-            }, 5);
-          });
-        });
-      };
-    });
-  });
-
-  it('sends Last-Event-ID http header when it has previously been passed in an event from the server', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
-
-      server.on('request', writeEvents(['id: 10\ndata: Hello\n\n']));
-
-      var es = new EventSource(server.url);
-      es.reconnectInterval = 0;
-
-      es.onmessage = function () {
-        server.close(function (err) {
-          if(err) return done(err);
-
-          var port = u.parse(es.url).port;
-          configureServer(http.createServer(), 'http', port, function (err, server2) {
-            server2.on('request', function (req, res) {
-              assert.equal('10', req.headers['last-event-id']);
-              server2.close(done);
+            server.on('request', function (req, res) {
+                res.writeHead(204);
+                res.end();
             });
-          });
+
+            var es = new EventSource(server.url);
+            es.reconnectInterval = 0;
+
+            es.onerror = function (e) {
+                assert.equal(e.status, 204);
+                server.close(function (err) {
+                    if (err) return done(err);
+
+                    var port = u.parse(es.url).port;
+                    configureServer(http.createServer(), 'http', port, function (err, server2) {
+                        if (err) return done(err);
+
+                        // this will be verified by the readyState
+                        // going from CONNECTING to CLOSED,
+                        // along with the tests verifying that the
+                        // state is CONNECTING when a server closes.
+                        // it's next to impossible to write a fail-safe
+                        // test for this, though.
+                        var ival = setInterval(function () {
+                            if (es.readyState == EventSource.CLOSED) {
+                                clearInterval(ival);
+                                server2.close(done);
+                            }
+                        }, 5);
+                    });
+                });
+            };
         });
-      };
     });
-  });
 
-  it('sends correct Last-Event-ID http header when an initial Last-Event-ID header was specified in the constructor', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('sends Last-Event-ID http header when it has previously been passed in an event from the server', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', function (req, res) {
-        assert.equal('9', req.headers['last-event-id']);
-        server.close(done);
-      });
+            server.on('request', writeEvents(['id: 10\ndata: Hello\n\n']));
 
-      new EventSource(server.url, {headers: {'Last-Event-ID': '9'}});
+            var es = new EventSource(server.url);
+            es.reconnectInterval = 0;
+
+            es.onmessage = function () {
+                server.close(function (err) {
+                    if (err) return done(err);
+
+                    var port = u.parse(es.url).port;
+                    configureServer(http.createServer(), 'http', port, function (err, server2) {
+                        server2.on('request', function (req, res) {
+                            assert.equal('10', req.headers['last-event-id']);
+                            server2.close(done);
+                        });
+                    });
+                });
+            };
+        });
     });
-  });
 
-  it('does not send Last-Event-ID http header when it has not been previously sent by the server', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('sends correct Last-Event-ID http header when an initial Last-Event-ID header was specified in the constructor', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(['data: Hello\n\n']));
-
-      var es = new EventSource(server.url);
-      es.reconnectInterval = 0;
-
-      es.onmessage = function () {
-        server.close(function (err) {
-          if(err) return done(err);
-
-          var port = u.parse(es.url).port;
-          configureServer(http.createServer(), 'http', port, function (err, server2) {
-            server2.on('request', function (req, res) {
-              assert.equal(undefined, req.headers['last-event-id']);
-              server2.close(done);
+            server.on('request', function (req, res) {
+                assert.equal('9', req.headers['last-event-id']);
+                server.close(done);
             });
-          });
+
+            new EventSource(server.url, {headers: {'Last-Event-ID': '9'}});
         });
-      };
     });
-  });
+
+    it('does not send Last-Event-ID http header when it has not been previously sent by the server', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
+
+            server.on('request', writeEvents(['data: Hello\n\n']));
+
+            var es = new EventSource(server.url);
+            es.reconnectInterval = 0;
+
+            es.onmessage = function () {
+                server.close(function (err) {
+                    if (err) return done(err);
+
+                    var port = u.parse(es.url).port;
+                    configureServer(http.createServer(), 'http', port, function (err, server2) {
+                        server2.on('request', function (req, res) {
+                            assert.equal(undefined, req.headers['last-event-id']);
+                            server2.close(done);
+                        });
+                    });
+                });
+            };
+        });
+    });
 });
 
 describe('readyState', function () {
-  it('has CONNECTING constant', function () {
-    assert.equal(0, EventSource.CONNECTING);
-  });
+    it('has CONNECTING constant', function () {
+        assert.equal(0, EventSource.CONNECTING);
+    });
 
-  it('has OPEN constant', function () {
-    assert.equal(1, EventSource.OPEN);
-  });
+    it('has OPEN constant', function () {
+        assert.equal(1, EventSource.OPEN);
+    });
 
-  it('has CLOSED constant', function () {
-    assert.equal(2, EventSource.CLOSED);
-  });
+    it('has CLOSED constant', function () {
+        assert.equal(2, EventSource.CLOSED);
+    });
 
-  it('is CONNECTING before connection has been established', function (done) {
-    var es = new EventSource('http://localhost:' + _port);
-    assert.equal(EventSource.CONNECTING, es.readyState);
-    es.onerror = function () {
-      es.close();
-      done();
-    }
-  });
-
-  it('is CONNECTING when server has closed the connection', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
-
-      server.on('request', writeEvents([]));
-      var es = new EventSource(server.url);
-      es.reconnectInterval = 0;
-
-      es.onopen = function (m) {
-        server.close(function (err) {
-          if(err) return done(err);
-
-          es.onerror = function () {
-            es.onerror = null;
-            assert.equal(EventSource.CONNECTING, es.readyState);
+    it('is CONNECTING before connection has been established', function (done) {
+        var es = new EventSource('http://localhost:' + _port);
+        assert.equal(EventSource.CONNECTING, es.readyState);
+        es.onerror = function () {
+            es.close();
             done();
-          };
+        }
+    });
+
+    it('is CONNECTING when server has closed the connection', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
+
+            server.on('request', writeEvents([]));
+            var es = new EventSource(server.url);
+            es.reconnectInterval = 0;
+
+            es.onopen = function (m) {
+                server.close(function (err) {
+                    if (err) return done(err);
+
+                    es.onerror = function () {
+                        es.onerror = null;
+                        assert.equal(EventSource.CONNECTING, es.readyState);
+                        done();
+                    };
+                });
+            };
         });
-      };
     });
-  });
 
-  it('is OPEN when connection has been established', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('is OPEN when connection has been established', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents([]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents([]));
+            var es = new EventSource(server.url);
 
-      es.onopen = function () {
-        assert.equal(EventSource.OPEN, es.readyState);
-        server.close(done);
-      }
+            es.onopen = function () {
+                assert.equal(EventSource.OPEN, es.readyState);
+                server.close(done);
+            }
+        });
     });
-  });
 
-  it('is CLOSED after connection has been closed', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('is CLOSED after connection has been closed', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents([]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents([]));
+            var es = new EventSource(server.url);
 
-      es.onopen = function () {
-        es.close();
-        assert.equal(EventSource.CLOSED, es.readyState);
-        server.close(done);
-      }
+            es.onopen = function () {
+                es.close();
+                assert.equal(EventSource.CLOSED, es.readyState);
+                server.close(done);
+            }
+        });
     });
-  });
 });
 
 describe('Properties', function () {
-  it('url exposes original request url', function () {
-    var url = 'http://localhost:' + _port;
-    var es = new EventSource(url);
-    assert.equal(url, es.url);
-  });
+    it('url exposes original request url', function () {
+        var url = 'http://localhost:' + _port;
+        var es = new EventSource(url);
+        assert.equal(url, es.url);
+    });
 });
 
 describe('Events', function () {
-  it('calls onopen when connection is established', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('calls onopen when connection is established', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents([]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents([]));
+            var es = new EventSource(server.url);
 
-      es.onopen = function (event) {
-        assert.equal(event.type, 'open');
-        server.close(done);
-      }
-    });
-  });
-
-  it('supplies the correct origin', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
-
-      server.on('request', writeEvents(["data: hello\n\n"]));
-      var es = new EventSource(server.url);
-
-      es.onmessage = function (event) {
-        assert.equal(event.origin, server.url);
-        server.close(done);
-      }
-    });
-  });
-
-  it('emits open event when connection is established', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
-
-      server.on('request', writeEvents([]));
-      var es = new EventSource(server.url);
-
-      es.addEventListener('open', function (event) {
-        assert.equal(event.type, 'open');
-        server.close(done);
-      });
-    });
-  });
-
-  it('does not emit error when connection is closed by client', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
-
-      server.on('request', writeEvents([]));
-      var es = new EventSource(server.url);
-
-      es.addEventListener('open', function () {
-        es.close();
-        process.nextTick(function () {
-          server.close(done);
+            es.onopen = function (event) {
+                assert.equal(event.type, 'open');
+                server.close(done);
+            }
         });
-      });
-      es.addEventListener('error', function () {
-        done(new Error('error should not be emitted'));
-      });
     });
-  });
 
-  it('populates message\'s lastEventId correctly when the last event has an associated id', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('supplies the correct origin', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["id: 123\ndata: hello\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents(["data: hello\n\n"]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = function (m) {
-        assert.equal(m.lastEventId, "123");
-        server.close(done);
-      };
+            es.onmessage = function (event) {
+                assert.equal(event.origin, server.url);
+                server.close(done);
+            }
+        });
     });
-  });
 
-  it('populates message\'s lastEventId correctly when the last event doesn\'t have an associated id', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('emits open event when connection is established', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["id: 123\ndata: Hello\n\n", "data: World\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents([]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = first;
-
-      function first() {
-        es.onmessage = second;
-      }
-
-      function second(m) {
-        assert.equal(m.data, "World");
-        assert.equal(m.lastEventId, "123");  //expect to get back the previous event id
-        server.close(done);
-      }
+            es.addEventListener('open', function (event) {
+                assert.equal(event.type, 'open');
+                server.close(done);
+            });
+        });
     });
-  });
 
-  it('populates messages with enumerable properties so they can be inspected via console.log().', function (done) {
-    createServer(function (err, server) {
-      if(err) return done(err);
+    it('does not emit error when connection is closed by client', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
 
-      server.on('request', writeEvents(["data: World\n\n"]));
-      var es = new EventSource(server.url);
+            server.on('request', writeEvents([]));
+            var es = new EventSource(server.url);
 
-      es.onmessage = function (m) {
-        var enumerableAttributes = Object.keys(m);
-        assert.notEqual(enumerableAttributes.indexOf("data"), -1);
-        assert.notEqual(enumerableAttributes.indexOf("type"), -1);
-        server.close(done);
-      };
+            es.addEventListener('open', function () {
+                es.close();
+                process.nextTick(function () {
+                    server.close(done);
+                });
+            });
+            es.addEventListener('error', function () {
+                done(new Error('error should not be emitted'));
+            });
+        });
     });
-  });
+
+    it('populates message\'s lastEventId correctly when the last event has an associated id', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
+
+            server.on('request', writeEvents(["id: 123\ndata: hello\n\n"]));
+            var es = new EventSource(server.url);
+
+            es.onmessage = function (m) {
+                assert.equal(m.lastEventId, "123");
+                server.close(done);
+            };
+        });
+    });
+
+    it('populates message\'s lastEventId correctly when the last event doesn\'t have an associated id', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
+
+            server.on('request', writeEvents(["id: 123\ndata: Hello\n\n", "data: World\n\n"]));
+            var es = new EventSource(server.url);
+
+            es.onmessage = first;
+
+            function first() {
+                es.onmessage = second;
+            }
+
+            function second(m) {
+                assert.equal(m.data, "World");
+                assert.equal(m.lastEventId, "123");  //expect to get back the previous event id
+                server.close(done);
+            }
+        });
+    });
+
+    it('populates messages with enumerable properties so they can be inspected via console.log().', function (done) {
+        createServer(function (err, server) {
+            if (err) return done(err);
+
+            server.on('request', writeEvents(["data: World\n\n"]));
+            var es = new EventSource(server.url);
+
+            es.onmessage = function (m) {
+                var enumerableAttributes = Object.keys(m);
+                assert.notEqual(enumerableAttributes.indexOf("data"), -1);
+                assert.notEqual(enumerableAttributes.indexOf("type"), -1);
+                server.close(done);
+            };
+        });
+    });
 });


### PR DESCRIPTION
Hi,

For one of the projects I am working on we want to bridge an sse stream to an amqp broker. Ideally we want to leverage your lib in combination with rxjs.

The issue I have is that this sse stream will contain lots of different events. Given the fact that the current code emits only specific events when the event name is set, I need to register for all of these events individually. 

I was wondering whether it made sense to you to add an extra emit with a 'message' key alongside the emit of the specific event. 

This would simplify my code a lot, as it allows me to do this :

````javascript
const source = new EventSource(baseUrl + '/changes/streaming?resources=posts,comments')
Rx.Observable.fromEvent(source, 'message')
    .subscribe((e)=> {
        //..
    })
````
rather than this

````javascript
const subject = new Rx.Subject()
const source = new EventSource(baseUrl + '/changes/streaming?resources=posts,comments')
_.map(['comments_i', 'comments_u', 'posts_i', 'posts_u'], (event)=> {
    Rx.Observable.fromEvent(source, event)
        .subscribe(subject)
})

subject.subscribe((e)=> {
    //..
})
````

Hope you don't mind I created this PR without discussing it up front, let me know if you are ok with the idea or you want me to make some changes.

Regards,

Kristof